### PR TITLE
mysql dependency

### DIFF
--- a/jenkins/jobs/python-jobs.yaml
+++ b/jenkins/jobs/python-jobs.yaml
@@ -4,7 +4,7 @@
     builders:
       - shell: |
           sudo apt-get -y update
-          sudo apt-get -y install -y libffi-dev libssl-dev mysql-server-core
+          sudo apt-get -y install -y libffi-dev libssl-dev mysql-server
 
 - job-template:
     name: 'master-{name}-coverage'


### PR DESCRIPTION
mysql_install_db is broken when only mysql-server-core is installed. Install mysql-server instead.