### PR TITLE
Share mysql-server with devstack

### DIFF
--- a/jenkins/jobs/python-jobs.yaml
+++ b/jenkins/jobs/python-jobs.yaml
@@ -4,6 +4,8 @@
     builders:
       - shell: |
           sudo apt-get -y update
+          sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password secretmysql'
+          sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password secretmysql'
           sudo apt-get -y install -y libffi-dev libssl-dev mysql-server
 
 - job-template:


### PR DESCRIPTION
Use the password devstack would use when it installs mysql-server so that devstack can use the installed mysql-server.

Uninstalling mysql-server is tenuous at best. The dev box I tried it on got hosed.